### PR TITLE
Fix: map undefined/null valued properties to the empty string in AutoCsvRowMapper.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2csv",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Angular2 module for saving CSV files.",
   "main": "Ng2Csv.bundle.js",
   "module": "Ng2Csv.module.js",

--- a/src/AutoCsvRowMapper.ts
+++ b/src/AutoCsvRowMapper.ts
@@ -22,7 +22,17 @@ export class AutoCsvRowMapper<T> implements ICsvRowMapper<T> {
     for (const property of Object.keys(firstRow)) {
       projections.push([
         property,
-        (x: T) => (x as any)[property].toString()
+        (x: T) => {
+          if (x.hasOwnProperty(property)) {
+            const propertyValue = (x as any)[property];
+            if (propertyValue === undefined || propertyValue === null) {
+              return '';
+            }
+            return propertyValue.toString();
+          } else {
+            return '';
+          }
+        }
       ]);
     }
 

--- a/test/AutoCsvRowMapper.spec.ts
+++ b/test/AutoCsvRowMapper.spec.ts
@@ -25,6 +25,16 @@ describe('AutoCsvRowMapper', () => {
       expect(row[0]).toBe('5');
       expect(row[1]).toBe('Alice');
     });
+
+    it('should map missing properties to the empty string', () => {
+      const row: string[] = rowMapper.map({
+        Id: undefined,
+        Name: 'Bob'
+      });
+      expect(row.length).toBe(2);
+      expect(row[0]).toBe('');
+      expect(row[1]).toBe('Bob');
+    });
   });
 
   describe('getColumnNames()', () => {


### PR DESCRIPTION
Rather than causing a runtime error before `.toString()`.
Related to issue: https://github.com/rars/ng2csv/issues/5