### PR TITLE
feat(Ng2Csv.service): allow configuration of output values for null and undefined values

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ csvConfig.includeHeaderRow = false;
 this.ng2Csv.download(myData, 'file.csv', undefined, csvConfig);
 ```
 
+### Null or undefined values
+You can control how `null` or `undefined` values are written out in config.
+```
+import { CsvConfiguration } from 'ng2csv';
+// ...
+const csvConfig = new CsvConfiguration();
+csvConfig.outputValueForNull = 'NULL';
+csvConfig.outputValueForUndefined = 'UNDEFINED';
+```
+
 ## Contributions welcome!
 If you have a feature or improvement you would like to see included, please raise an issue or a PR and I will review.
 

--- a/src/CsvConfiguration.ts
+++ b/src/CsvConfiguration.ts
@@ -3,4 +3,6 @@ export class CsvConfiguration {
   public quote: string = '"';
   public newLine: string = '\r\n';
   public includeHeaderLine: boolean = true;
+  public outputValueForNull: string = '';
+  public outputValueForUndefined: string = '';
 }

--- a/src/Ng2Csv.service.ts
+++ b/src/Ng2Csv.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import * as FileSaver from 'file-saver';
+import { saveAs } from 'file-saver';
 import { AutoCsvRowMapper } from './AutoCsvRowMapper';
 import { CsvConfiguration } from './CsvConfiguration';
 import { ICsvRowMapper } from './ICsvRowMapper';
@@ -17,7 +17,7 @@ export class Ng2CsvService {
       + (config.includeHeaderLine ? 'present' : 'absent');
 
     const csvBlob: Blob = new Blob([csvData], { type: mimeType });
-    FileSaver.saveAs(csvBlob, filename, true);
+    saveAs(csvBlob, filename, true);
   }
 
   public convertToCsv<T>(
@@ -42,11 +42,28 @@ export class Ng2CsvService {
 
     for (const row of data) {
       rows.push(csvRowMapper.map(row)
+        .map(x => this.mapNullOrUndefinedValues(x, config))
         .map(x => this.escapeRowValue(x, config))
         .join(config.delimiter));
     }
 
     return rows.join(config.newLine);
+  }
+
+  private mapNullOrUndefinedValues(
+      value: string,
+      config: CsvConfiguration): string {
+    switch (value) {
+      case null: {
+        return config.outputValueForNull;
+      }
+      case undefined: {
+        return config.outputValueForUndefined;
+      }
+      default: {
+        return value;
+      }
+    }
   }
 
   private escapeQuotes(

--- a/test/Ng2Csv.service.spec.ts
+++ b/test/Ng2Csv.service.spec.ts
@@ -72,5 +72,82 @@ describe('Ng2CsvService', () => {
           '"id","name"\r\n'
           + '"1,000","Smith, Alice"\r\n2,"""Bob"" Smith"');
       }));
+
+    it('should output null values as configured value',
+      inject([Ng2CsvService], (ng2CsvService: Ng2CsvService) => {
+        const config = new CsvConfiguration();
+        config.outputValueForNull = 'NULL';
+
+        const csv = ng2CsvService.convertToCsv([
+            {
+              id: 'X1000',
+              name: 'Alice'
+            },
+            {
+              id: null,
+              name: 'Bob'
+            }
+          ],
+          new OrderedProjectionCsvRowMapper([
+            ['Id', x => x.id],
+            ['Name', x => x.name]
+          ]),
+          config);
+
+        expect(csv).toBe(
+          '"Id","Name"\r\n'
+          + 'X1000,Alice\r\nNULL,Bob'
+        );
+      }));
+
+    it('should output undefined values as configured value',
+      inject([Ng2CsvService], (ng2CsvService: Ng2CsvService) => {
+        const config = new CsvConfiguration();
+        config.outputValueForUndefined = 'UNDEFINED';
+
+        const csv = ng2CsvService.convertToCsv([
+            {
+              id: 'X1000',
+              name: 'Alice'
+            },
+            {
+              id: undefined,
+              name: 'Bob'
+            }
+          ],
+          new OrderedProjectionCsvRowMapper([
+            ['Id', x => x.id],
+            ['Name', x => x.name]
+          ]),
+          config);
+
+        expect(csv).toBe(
+          '"Id","Name"\r\n'
+          + 'X1000,Alice\r\nUNDEFINED,Bob'
+        );
+      }));
+
+    it('should output null/undefined values as empty string by default',
+      inject([Ng2CsvService], (ng2CsvService: Ng2CsvService) => {
+        const csv = ng2CsvService.convertToCsv([
+            {
+              id: 'X1000',
+              name: null
+            },
+            {
+              id: undefined,
+              name: 'Bob'
+            }
+          ],
+          new OrderedProjectionCsvRowMapper([
+            ['Id', x => x.id],
+            ['Name', x => x.name]
+          ]));
+
+        expect(csv).toBe(
+          '"Id","Name"\r\n'
+          + 'X1000,\r\n,Bob'
+        );
+      }));
   });
 });


### PR DESCRIPTION
If a field value is `null` or `undefined` then `outputValueForNull` or `outputValueForUndefined` will be written out in its place. These default to the empty string, so e.g. `null` values would appear in the CSV as empty columns: `valueOne,,valueTwo`.

fix issue #9